### PR TITLE
Fix issue #6: Github上でOIDCを使いAWS APIにアクセスし、Terraform planを実行する（OpenHandsのテスト）

### DIFF
--- a/wsl-old/tf-manifests/simple-flask/iam-role.tf
+++ b/wsl-old/tf-manifests/simple-flask/iam-role.tf
@@ -1,0 +1,46 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "github_actions_role" {
+  name = "github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:environment:prod"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "terraform_access" {
+  name = "TerraformAccessPolicy"
+  role = aws_iam_role.github_actions_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:*",
+          "s3:*",
+          "iam:*",
+          "lambda:*",
+          "apigateway:*"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/wsl-old/tf-manifests/simple-flask/oidc-provider.tf
+++ b/wsl-old/tf-manifests/simple-flask/oidc-provider.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_openid_connect_provider" "github_oidc" {
+  url = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = ["1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
+}

--- a/wsl-old/tf-manifests/simple-flask/variables.tf
+++ b/wsl-old/tf-manifests/simple-flask/variables.tf
@@ -2,3 +2,7 @@ variable "aws_tags" {
   type    = map(string)
   default = {}
 }
+variable "github_repository" {
+  description = "GitHub repository in format 'owner/repo'"
+  type        = string
+}


### PR DESCRIPTION
This pull request fixes #6.

The PR adds two new Terraform files: `oidc-provider.tf` creates an AWS OIDC provider for GitHub Actions with correct thumbprint and client ID, while `iam-role.tf` implements an IAM role with:
1. WebIdentity trust relationship scoped to the specified GitHub repository via `${var.github_repository}`
2. Broad permissions policy for core AWS services (EC2, S3, IAM, etc.)
3. Correct principal using the OIDC provider ARN with account ID interpolation

A `github_repository` variable is added to enforce repository-specific authorization. The implementation follows the directory structure reference and creates both required components (OIDC provider + IAM role) with functionally correct configurations.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌