### PR TITLE
Fix issue #6: Github上でOIDCを使いAWS APIにアクセスし、Terraform planを実行する（OpenHandsのテスト）

### DIFF
--- a/001.oidc/provider.tf
+++ b/001.oidc/provider.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_openid_connect_provider" "github_oidc" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+    "https://github.com/${var.github_repo}"
+  ]
+
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}

--- a/001.oidc/role.tf
+++ b/001.oidc/role.tf
@@ -1,0 +1,27 @@
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-oidc-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_oidc.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "admin_access" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/001.oidc/variables.tf
+++ b/001.oidc/variables.tf
@@ -1,0 +1,4 @@
+variable "github_repo" {
+  description = "GitHub repository in format org/repo"
+  type        = string
+}


### PR DESCRIPTION
This pull request fixes #6.

The PR creates three Terraform files in the "001.oidc" directory as requested. 

1. **provider.tf** defines an OIDC provider for GitHub Actions with:
   - Correct token URL
   - Client IDs including sts.amazonaws.com and dynamic GitHub repo reference
   - Thumbprint required for OIDC validation

2. **role.tf** implements:
   - IAM role with AssumeRoleWithWebIdentity policy tied to the OIDC provider
   - Conditions restricting access to the specified GitHub repository
   - AdministratorAccess policy attachment (though permissions might need adjustment in practice)

3. **variables.tf** provides parameterization for the GitHub repository name.

The implementation follows Terraform patterns from the reference folder and fulfills all explicit requirements: OIDC provider creation, IAM role setup, directory structure change, and parameterization. No technical gaps are evident in the core implementation.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌