### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-gen-linter-pr.yml
+++ b/.github/workflows/terraform-gen-linter-pr.yml
@@ -1,5 +1,10 @@
 name: Terraform Generate linter and PR
 
+permissions:
+  contents: write
+  actions: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/4](https://github.com/kohei39san/mystudy-handson/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: write` for creating pull requests and modifying files.
- `actions: read` for accessing workflow artifacts.
- `pull-requests: write` for managing pull requests.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
