### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-linter-pr.yml
+++ b/.github/workflows/terraform-linter-pr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/3](https://github.com/kohei39san/mystudy-handson/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed to check out the repository.
- The `pull-requests: write` permission is required to create a pull request using the `peter-evans/create-pull-request@v7` action.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
