### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-pr-from-openhands-resolver.yml
+++ b/.github/workflows/create-pr-from-openhands-resolver.yml
@@ -2,6 +2,10 @@ name: Create Pull Request From OpenHands Resolver
 
 on: create
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-pr:
     if: ${{ contains(github.ref, 'refs/heads/openhands-fix-issue-') }}


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/2](https://github.com/kohei39san/mystudy-handson/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow. Based on the workflow's functionality, it primarily interacts with repository contents (e.g., checking out the repository) and creates pull requests. Therefore, we will set `contents: read` and `pull-requests: write` permissions. These permissions are sufficient for the workflow's operations while adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
