### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cfn-linter-pr.yml
+++ b/.github/workflows/cfn-linter-pr.yml
@@ -1,5 +1,9 @@
 name: CloudFormation linter and PR
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/1](https://github.com/kohei39san/mystudy-handson/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: write` for creating pull requests and modifying files.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
