### PR TITLE
Potential fix for code scanning alert no. 109: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-linter.yml
+++ b/.github/workflows/github-actions-linter.yml
@@ -1,5 +1,8 @@
 name: GitHub Actions Linter
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/109](https://github.com/kohei39san/mystudy-handson/security/code-scanning/109)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs linting operations, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `lint` job if other jobs in the workflow require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
