### PR TITLE
Potential fix for code scanning alert no. 110: Clear-text logging of sensitive information

### DIFF
--- a/021.slack-lambda-mcp-server/scripts/py/lambda_function.py
+++ b/021.slack-lambda-mcp-server/scripts/py/lambda_function.py
@@ -46,7 +46,7 @@ def get_parameter(param_name):
         )
         return response['Parameter']['Value']
     except Exception as e:
-        logger.error(f"Error retrieving parameter {param_name}: {str(e)}")
+        logger.error(f"Error retrieving parameter: {str(e)}")
         raise
 
 def start_mcp_servers():


### PR DESCRIPTION
Potential fix for [https://github.com/kohei39san/mystudy-handson/security/code-scanning/110](https://github.com/kohei39san/mystudy-handson/security/code-scanning/110)

To fix the problem, we should avoid logging the sensitive parameter name in error messages. Instead, we can log a generic error message that does not include the parameter name, or we can log only non-sensitive context (such as the fact that a parameter retrieval failed). The change should be made in the `get_parameter` function, specifically on line 49, where the error is logged. No additional imports or methods are needed; only the error message should be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
