### PR TITLE
fix(040): add SG port details and Azure subnet NSG observation

### DIFF
--- a/040.network-connectivity-checker/README.md
+++ b/040.network-connectivity-checker/README.md
@@ -254,12 +254,86 @@ python scripts/check_network_connectivity.py \
     "public_subnet": true,
     "private_ip": "10.0.1.10",
     "public_ip": "203.0.113.10",
-    "public_ip_assigned": true
+    "public_ip_assigned": true,
+    "security_groups": [
+      {
+        "group_id": "sg-0123456789abcdef0",
+        "group_name": "web-sg",
+        "ingress_rules": [
+          {
+            "cidr": "0.0.0.0/0",
+            "protocol": "tcp",
+            "from_port": 443,
+            "to_port": 443
+          }
+        ],
+        "egress_rules": [
+          {
+            "cidr": "0.0.0.0/0",
+            "protocol": "-1",
+            "from_port": null,
+            "to_port": null
+          }
+        ]
+      }
+    ]
   }
 }
 ```
 
 サンプル出力は `sample_output/` ディレクトリを参照してください。
+
+Azure VM の場合、`observed` には NSG 情報として以下が含まれます。
+
+```json
+{
+  "power_state": "running",
+  "private_ips": ["10.0.0.4"],
+  "public_ips": ["1.2.3.4"],
+  "subnet_ids": [
+    "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet>"
+  ],
+  "has_udr": false,
+  "nsg_rules": [
+    {
+      "nsg_name": "nic-nsg",
+      "allow_rules": [
+        {
+          "name": "AllowHTTPS",
+          "direction": "Inbound",
+          "priority": 100,
+          "protocol": "Tcp",
+          "source_address_prefix": "0.0.0.0/0",
+          "destination_address_prefix": "*",
+          "destination_port_range": "443"
+        }
+      ]
+    }
+  ],
+  "subnet_nsg_rules": [
+    {
+      "nsg_name": "subnet-nsg",
+      "allow_rules": [
+        {
+          "name": "AllowHTTPS",
+          "direction": "Inbound",
+          "priority": 100,
+          "protocol": "Tcp",
+          "source_address_prefix": "0.0.0.0/0",
+          "destination_address_prefix": "*",
+          "destination_port_range": "443"
+        }
+      ]
+    }
+  ]
+}
+```
+
+また `reasons` には、NSG の観測有無として以下が追加されます。
+
+- `nsg_rules_present_nic=true|false`
+- `nsg_rules_present_subnet=true|false`
+- `nsg_rules_present=true|false`（上記どちらかが true なら true）
 
 ---
 
@@ -289,6 +363,7 @@ python scripts/check_network_connectivity.py \
 | `power_state=running` | 必須 | 必須 |
 | Public IP あり | 必須 | 不要 |
 | Private IP あり | 不要 | 必須 |
+| NIC NSG / Subnet NSG（allow ルール観測） | 参考情報 | 参考情報 |
 
 ### GCP Compute Engine
 

--- a/040.network-connectivity-checker/sample_output/azure_vm_sample.json
+++ b/040.network-connectivity-checker/sample_output/azure_vm_sample.json
@@ -8,6 +8,8 @@
     "power_state=running",
     "public_ip_assigned=true",
     "has_udr=false",
+    "nsg_rules_present_nic=true",
+    "nsg_rules_present_subnet=true",
     "nsg_rules_present=true"
   ],
   "observed": {
@@ -26,6 +28,22 @@
             "name": "AllowHTTPS",
             "direction": "Inbound",
             "priority": 100,
+            "protocol": "Tcp",
+            "source_address_prefix": "0.0.0.0/0",
+            "destination_address_prefix": "*",
+            "destination_port_range": "443"
+          }
+        ]
+      }
+    ],
+    "subnet_nsg_rules": [
+      {
+        "nsg_name": "my-subnet-nsg",
+        "allow_rules": [
+          {
+            "name": "AllowHTTPS",
+            "direction": "Inbound",
+            "priority": 110,
             "protocol": "Tcp",
             "source_address_prefix": "0.0.0.0/0",
             "destination_address_prefix": "*",

--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -79,28 +79,91 @@ def _sg_rules_summary(sg_list: List[Dict]) -> Tuple[List[str], List[str]]:
     Returns (ingress_cidrs, egress_cidrs) – lists of allowed CIDR strings
     extracted from the provided security group dictionaries.
     """
-    ingress_cidrs: List[str] = []
-    egress_cidrs: List[str] = []
+    ingress_rules, egress_rules = _sg_rules_with_ports(sg_list)
+    ingress_cidrs = [r["cidr"] for r in ingress_rules if r.get("cidr")]
+    egress_cidrs = [r["cidr"] for r in egress_rules if r.get("cidr")]
+    return ingress_cidrs, egress_cidrs
+
+
+def _sg_rules_with_ports(sg_list: List[Dict]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """
+    Returns (ingress_rules, egress_rules) where each rule contains:
+      - cidr
+      - protocol
+      - from_port
+      - to_port
+    """
+    ingress_rules: List[Dict[str, Any]] = []
+    egress_rules: List[Dict[str, Any]] = []
+
     for sg in sg_list:
         for perm in sg.get("IpPermissions", []):
+            protocol = perm.get("IpProtocol", "")
+            from_port = perm.get("FromPort")
+            to_port = perm.get("ToPort")
+
             for r in perm.get("IpRanges", []):
                 cidr = r.get("CidrIp", "")
                 if cidr:
-                    ingress_cidrs.append(cidr)
+                    ingress_rules.append(
+                        {
+                            "cidr": cidr,
+                            "protocol": protocol,
+                            "from_port": from_port,
+                            "to_port": to_port,
+                        }
+                    )
             for r in perm.get("Ipv6Ranges", []):
                 cidr = r.get("CidrIpv6", "")
                 if cidr:
-                    ingress_cidrs.append(cidr)
+                    ingress_rules.append(
+                        {
+                            "cidr": cidr,
+                            "protocol": protocol,
+                            "from_port": from_port,
+                            "to_port": to_port,
+                        }
+                    )
+
         for perm in sg.get("IpPermissionsEgress", []):
+            protocol = perm.get("IpProtocol", "")
+            from_port = perm.get("FromPort")
+            to_port = perm.get("ToPort")
+
             for r in perm.get("IpRanges", []):
                 cidr = r.get("CidrIp", "")
                 if cidr:
-                    egress_cidrs.append(cidr)
+                    egress_rules.append(
+                        {
+                            "cidr": cidr,
+                            "protocol": protocol,
+                            "from_port": from_port,
+                            "to_port": to_port,
+                        }
+                    )
             for r in perm.get("Ipv6Ranges", []):
                 cidr = r.get("CidrIpv6", "")
                 if cidr:
-                    egress_cidrs.append(cidr)
-    return ingress_cidrs, egress_cidrs
+                    egress_rules.append(
+                        {
+                            "cidr": cidr,
+                            "protocol": protocol,
+                            "from_port": from_port,
+                            "to_port": to_port,
+                        }
+                    )
+
+    return ingress_rules, egress_rules
+
+
+def _sg_observed(sg: Dict[str, Any]) -> Dict[str, Any]:
+    ingress_rules, egress_rules = _sg_rules_with_ports([sg])
+    return {
+        "group_id": sg["GroupId"],
+        "group_name": sg.get("GroupName", ""),
+        "ingress_rules": ingress_rules,
+        "egress_rules": egress_rules,
+    }
 
 
 def _is_public_subnet(ec2_client, subnet_id: str) -> bool:
@@ -202,41 +265,7 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
         "private_ip": private_ip,
         "public_ip": public_ip or None,
         "public_ip_assigned": public_ip_assigned,
-        "security_groups": [
-            {
-                "group_id": sg["GroupId"],
-                "group_name": sg.get("GroupName", ""),
-                "ingress_cidrs": [
-                    cidr
-                    for perm in sg.get("IpPermissions", [])
-                    for r in perm.get("IpRanges", [])
-                    for cidr in [r.get("CidrIp", "")]
-                    if cidr
-                ]
-                + [
-                    cidr
-                    for perm in sg.get("IpPermissions", [])
-                    for r in perm.get("Ipv6Ranges", [])
-                    for cidr in [r.get("CidrIpv6", "")]
-                    if cidr
-                ],
-                "egress_cidrs": [
-                    cidr
-                    for perm in sg.get("IpPermissionsEgress", [])
-                    for r in perm.get("IpRanges", [])
-                    for cidr in [r.get("CidrIp", "")]
-                    if cidr
-                ]
-                + [
-                    cidr
-                    for perm in sg.get("IpPermissionsEgress", [])
-                    for r in perm.get("Ipv6Ranges", [])
-                    for cidr in [r.get("CidrIpv6", "")]
-                    if cidr
-                ],
-            }
-            for sg in sgs
-        ],
+        "security_groups": [_sg_observed(sg) for sg in sgs],
     }
 
     # ── Reasons ──────────────────────────────────────────────────────────────
@@ -321,41 +350,7 @@ def check_aws_rds(resource_id: str, region: Optional[str] = None) -> Dict[str, A
         "subnet_ids": subnet_ids,
         "endpoint": endpoint_address,
         "port": endpoint_port,
-        "security_groups": [
-            {
-                "group_id": sg["GroupId"],
-                "group_name": sg.get("GroupName", ""),
-                "ingress_cidrs": [
-                    cidr
-                    for perm in sg.get("IpPermissions", [])
-                    for r in perm.get("IpRanges", [])
-                    for cidr in [r.get("CidrIp", "")]
-                    if cidr
-                ]
-                + [
-                    cidr
-                    for perm in sg.get("IpPermissions", [])
-                    for r in perm.get("Ipv6Ranges", [])
-                    for cidr in [r.get("CidrIpv6", "")]
-                    if cidr
-                ],
-                "egress_cidrs": [
-                    cidr
-                    for perm in sg.get("IpPermissionsEgress", [])
-                    for r in perm.get("IpRanges", [])
-                    for cidr in [r.get("CidrIp", "")]
-                    if cidr
-                ]
-                + [
-                    cidr
-                    for perm in sg.get("IpPermissionsEgress", [])
-                    for r in perm.get("Ipv6Ranges", [])
-                    for cidr in [r.get("CidrIpv6", "")]
-                    if cidr
-                ],
-            }
-            for sg in sgs
-        ],
+        "security_groups": [_sg_observed(sg) for sg in sgs],
     }
 
     reasons.append(f"db_state={db_state}")
@@ -416,6 +411,25 @@ def _parse_azure_resource_id(resource_id: str) -> Dict[str, str]:
     return result
 
 
+def _azure_collect_allow_rules(nsg: Any) -> List[Dict[str, Any]]:
+    """Collect allow rules from an Azure NSG object."""
+    rules: List[Dict[str, Any]] = []
+    for rule in nsg.security_rules or []:
+        if rule.access and rule.access.lower() == "allow":
+            rules.append(
+                {
+                    "name": rule.name,
+                    "direction": rule.direction,
+                    "priority": rule.priority,
+                    "protocol": rule.protocol,
+                    "source_address_prefix": rule.source_address_prefix or "",
+                    "destination_address_prefix": rule.destination_address_prefix or "",
+                    "destination_port_range": rule.destination_port_range or "",
+                }
+            )
+    return rules
+
+
 def check_azure_vm(resource_id: str) -> Dict[str, Any]:
     """Check network reachability for an Azure Virtual Machine."""
     try:
@@ -458,8 +472,10 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
     private_ips: List[str] = []
     public_ips: List[str] = []
     nsg_rules_info: List[Dict] = []
+    subnet_nsg_rules_info: List[Dict] = []
     subnet_ids: List[str] = []
     has_udr = False
+    seen_subnet_nsg_ids: set[str] = set()
 
     # Iterate NICs
     for nic_ref in vm.network_profile.network_interfaces or []:
@@ -498,6 +514,23 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
                     subnet_obj = network_client.subnets.get(sub_rg, vnet_name, subnet_name)
                     if subnet_obj.route_table:
                         has_udr = True
+
+                    if subnet_obj.network_security_group and subnet_obj.network_security_group.id:
+                        subnet_nsg_id = subnet_obj.network_security_group.id
+                        if subnet_nsg_id not in seen_subnet_nsg_ids:
+                            seen_subnet_nsg_ids.add(subnet_nsg_id)
+                            subnet_nsg_parts = _parse_azure_resource_id(subnet_nsg_id)
+                            subnet_nsg_rg = subnet_nsg_parts.get("resourcegroups", sub_rg)
+                            subnet_nsg_name = subnet_nsg_parts.get("networksecuritygroups", "")
+                            if subnet_nsg_name:
+                                subnet_nsg = network_client.network_security_groups.get(subnet_nsg_rg, subnet_nsg_name)
+                                subnet_allow_rules = _azure_collect_allow_rules(subnet_nsg)
+                                subnet_nsg_rules_info.append(
+                                    {
+                                        "nsg_name": subnet_nsg_name,
+                                        "allow_rules": subnet_allow_rules,
+                                    }
+                                )
                 except Exception:
                     pass
 
@@ -508,20 +541,7 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
             nsg_name = nsg_parts.get("networksecuritygroups", "")
             try:
                 nsg = network_client.network_security_groups.get(nsg_rg, nsg_name)
-                nsg_rules = []
-                for rule in nsg.security_rules or []:
-                    if rule.access and rule.access.lower() == "allow":
-                        nsg_rules.append(
-                            {
-                                "name": rule.name,
-                                "direction": rule.direction,
-                                "priority": rule.priority,
-                                "protocol": rule.protocol,
-                                "source_address_prefix": rule.source_address_prefix or "",
-                                "destination_address_prefix": rule.destination_address_prefix or "",
-                                "destination_port_range": rule.destination_port_range or "",
-                            }
-                        )
+                nsg_rules = _azure_collect_allow_rules(nsg)
                 nsg_rules_info.append({"nsg_name": nsg_name, "allow_rules": nsg_rules})
             except Exception:
                 pass
@@ -534,12 +554,15 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
         "subnet_ids": subnet_ids,
         "has_udr": has_udr,
         "nsg_rules": nsg_rules_info,
+        "subnet_nsg_rules": subnet_nsg_rules_info,
     }
 
     reasons.append(f"power_state={power_state}")
     reasons.append(f"public_ip_assigned={str(bool(public_ips)).lower()}")
     reasons.append(f"has_udr={str(has_udr).lower()}")
-    if nsg_rules_info:
+    reasons.append(f"nsg_rules_present_nic={str(bool(nsg_rules_info)).lower()}")
+    reasons.append(f"nsg_rules_present_subnet={str(bool(subnet_nsg_rules_info)).lower()}")
+    if nsg_rules_info or subnet_nsg_rules_info:
         reasons.append("nsg_rules_present=true")
 
     running = power_state.lower() == "running"

--- a/040.network-connectivity-checker/tests/test_check_network_connectivity.py
+++ b/040.network-connectivity-checker/tests/test_check_network_connectivity.py
@@ -46,12 +46,18 @@ def _make_sg(group_id="sg-111", ingress_cidrs=None, egress_cidrs=None):
         "GroupName": "test-sg",
         "IpPermissions": [
             {
+                "IpProtocol": "tcp",
+                "FromPort": 443,
+                "ToPort": 443,
                 "IpRanges": [{"CidrIp": cidr} for cidr in ingress_cidrs],
                 "Ipv6Ranges": [],
             }
         ],
         "IpPermissionsEgress": [
             {
+                "IpProtocol": "-1",
+                "FromPort": None,
+                "ToPort": None,
                 "IpRanges": [{"CidrIp": cidr} for cidr in egress_cidrs],
                 "Ipv6Ranges": [],
             }
@@ -102,12 +108,53 @@ class TestSgRulesSummary:
     def test_ipv6_included(self):
         sg = {
             "GroupId": "sg-v6",
-            "IpPermissions": [{"IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}]}],
-            "IpPermissionsEgress": [{"IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}]}],
+            "IpPermissions": [{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}]}],
+            "IpPermissionsEgress": [{"IpProtocol": "-1", "FromPort": None, "ToPort": None, "IpRanges": [], "Ipv6Ranges": [{"CidrIpv6": "::/0"}]}],
         }
         ing, eg = cnc._sg_rules_summary([sg])
         assert "::/0" in ing
         assert "::/0" in eg
+
+
+class TestSgRulesWithPorts:
+    """Tests for _sg_rules_with_ports helper."""
+
+    def test_extracts_ports_and_protocol_for_ipv4(self):
+        sg = _make_sg(ingress_cidrs=["10.0.0.0/16"], egress_cidrs=["0.0.0.0/0"])
+        ingress_rules, egress_rules = cnc._sg_rules_with_ports([sg])
+
+        assert ingress_rules[0]["cidr"] == "10.0.0.0/16"
+        assert ingress_rules[0]["protocol"] == "tcp"
+        assert ingress_rules[0]["from_port"] == 443
+        assert ingress_rules[0]["to_port"] == 443
+
+        assert egress_rules[0]["cidr"] == "0.0.0.0/0"
+        assert egress_rules[0]["protocol"] == "-1"
+        assert egress_rules[0]["from_port"] is None
+        assert egress_rules[0]["to_port"] is None
+
+    def test_extracts_ports_and_protocol_for_ipv6(self):
+        sg = {
+            "GroupId": "sg-v6",
+            "GroupName": "sg-v6",
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 8443,
+                    "ToPort": 8443,
+                    "IpRanges": [],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+                }
+            ],
+            "IpPermissionsEgress": [],
+        }
+
+        ingress_rules, egress_rules = cnc._sg_rules_with_ports([sg])
+        assert len(egress_rules) == 0
+        assert ingress_rules[0]["cidr"] == "::/0"
+        assert ingress_rules[0]["protocol"] == "tcp"
+        assert ingress_rules[0]["from_port"] == 8443
+        assert ingress_rules[0]["to_port"] == 8443
 
 
 class TestParseAzureResourceId:
@@ -271,6 +318,14 @@ class TestAwsEc2:
             assert key in result
         assert result["provider"] == "aws"
         assert result["resource_type"] == "ec2"
+        observed_sg = result["observed"]["security_groups"][0]
+        assert "ingress_rules" in observed_sg
+        assert "egress_rules" in observed_sg
+        assert "ingress_cidrs" not in observed_sg
+        assert "egress_cidrs" not in observed_sg
+        assert observed_sg["ingress_rules"][0]["protocol"] == "tcp"
+        assert observed_sg["ingress_rules"][0]["from_port"] == 443
+        assert observed_sg["ingress_rules"][0]["to_port"] == 443
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -392,6 +447,14 @@ class TestAwsRds:
         assert result["resource_type"] == "rds"
         assert result["observed"]["db_state"] == "available"
         assert result["observed"]["publicly_accessible"] is True
+        observed_sg = result["observed"]["security_groups"][0]
+        assert "ingress_rules" in observed_sg
+        assert "egress_rules" in observed_sg
+        assert "ingress_cidrs" not in observed_sg
+        assert "egress_cidrs" not in observed_sg
+        assert observed_sg["ingress_rules"][0]["protocol"] == "tcp"
+        assert observed_sg["ingress_rules"][0]["from_port"] == 443
+        assert observed_sg["ingress_rules"][0]["to_port"] == 443
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -527,6 +590,53 @@ class TestAzureVm:
 
         assert result["internet_reachability"] == cnc.NOT_REACHABLE
         assert result["private_reachability"] == cnc.NOT_REACHABLE
+
+    def test_subnet_nsg_is_collected(self):
+        vm = self._make_vm(power_state="running")
+        nic = self._make_nic(
+            private_ip="10.0.0.4",
+            subnet_id=(
+                "/subscriptions/sub-123/resourceGroups/rg1"
+                "/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
+            ),
+        )
+
+        subnet_obj = MagicMock()
+        subnet_obj.route_table = None
+        subnet_nsg_ref = MagicMock()
+        subnet_nsg_ref.id = (
+            "/subscriptions/sub-123/resourceGroups/rg1"
+            "/providers/Microsoft.Network/networkSecurityGroups/subnet-nsg"
+        )
+        subnet_obj.network_security_group = subnet_nsg_ref
+
+        subnet_nsg = self._make_nsg()
+
+        mock_compute_cls = MagicMock()
+        mock_network_cls = MagicMock()
+        mock_cred = MagicMock()
+
+        compute_client = MagicMock()
+        compute_client.virtual_machines.get.return_value = vm
+        mock_compute_cls.return_value = compute_client
+
+        network_client = MagicMock()
+        network_client.network_interfaces.get.return_value = nic
+        network_client.subnets.get.return_value = subnet_obj
+        network_client.network_security_groups.get.return_value = subnet_nsg
+        mock_network_cls.return_value = network_client
+
+        with patch.dict("sys.modules", {
+            "azure.identity": MagicMock(DefaultAzureCredential=mock_cred),
+            "azure.mgmt.compute": MagicMock(ComputeManagementClient=mock_compute_cls),
+            "azure.mgmt.network": MagicMock(NetworkManagementClient=mock_network_cls),
+        }):
+            result = cnc.check_azure_vm(self.RESOURCE_ID)
+
+        assert result["observed"]["subnet_nsg_rules"]
+        assert result["observed"]["subnet_nsg_rules"][0]["nsg_name"] == "subnet-nsg"
+        assert "nsg_rules_present_subnet=true" in result["reasons"]
+        assert "nsg_rules_present_nic=false" in result["reasons"]
 
     def test_invalid_resource_id_raises(self):
         with pytest.raises(ValueError, match="resource_id must be a full Azure resource ID"):


### PR DESCRIPTION
## Summary
- Add AWS Security Group rule details to observed output using ingress_rules/egress_rules with cidr/protocol/from_port/to_port
- Keep CIDR summary reasons for AWS EC2/RDS
- Add Azure subnet-level NSG observation in addition to NIC NSG
- Add reasons flags for Azure NSG visibility: nsg_rules_present_nic/subnet
- Update tests and README/sample output accordingly

## Validation
- pytest 040.network-connectivity-checker/tests/test_check_network_connectivity.py (passed)
