### PR TITLE
fix(040): use location-scoped Cloud Run service get

### DIFF
--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -811,11 +811,11 @@ def check_gcp_cloudrun(resource_id: str) -> Dict[str, Any]:
 
     service = _build_gcp_service("run", "v1")
 
-    # Cloud Run v1 uses namespaces (project) and locations
     cr_service = (
-        service.namespaces()
+        service.projects()
+        .locations()
         .services()
-        .get(name=f"namespaces/{project}/services/{service_name}")
+        .get(name=f"projects/{project}/locations/{location}/services/{service_name}")
         .execute()
     )
 

--- a/040.network-connectivity-checker/tests/test_check_network_connectivity.py
+++ b/040.network-connectivity-checker/tests/test_check_network_connectivity.py
@@ -797,7 +797,7 @@ class TestGcpCloudRun:
         iam_policy = self._make_iam_policy(allow_unauthenticated=True)
 
         service = MagicMock()
-        service.namespaces.return_value.services.return_value.get.return_value.execute.return_value = cr_data
+        service.projects.return_value.locations.return_value.services.return_value.get.return_value.execute.return_value = cr_data
         service.projects.return_value.locations.return_value.services.return_value.getIamPolicy.return_value.execute.return_value = iam_policy
         mock_build.return_value = service
 
@@ -813,7 +813,7 @@ class TestGcpCloudRun:
         iam_policy = self._make_iam_policy(allow_unauthenticated=False)
 
         service = MagicMock()
-        service.namespaces.return_value.services.return_value.get.return_value.execute.return_value = cr_data
+        service.projects.return_value.locations.return_value.services.return_value.get.return_value.execute.return_value = cr_data
         service.projects.return_value.locations.return_value.services.return_value.getIamPolicy.return_value.execute.return_value = iam_policy
         mock_build.return_value = service
 
@@ -828,7 +828,7 @@ class TestGcpCloudRun:
         iam_policy = self._make_iam_policy(allow_unauthenticated=False)
 
         service = MagicMock()
-        service.namespaces.return_value.services.return_value.get.return_value.execute.return_value = cr_data
+        service.projects.return_value.locations.return_value.services.return_value.get.return_value.execute.return_value = cr_data
         service.projects.return_value.locations.return_value.services.return_value.getIamPolicy.return_value.execute.return_value = iam_policy
         mock_build.return_value = service
 


### PR DESCRIPTION
## Summary
- Fix check_gcp_cloudrun to retrieve Cloud Run service with location-scoped resource path
- Replace 
amespaces/{project}/services/{service} call with projects/{project}/locations/{location}/services/{service}
- Update Cloud Run unit test mocks accordingly

## Why
Cloud Run service existed in the target project/region, but checker returned HTTP 404 due to non-location-scoped service retrieval path.

## Validation
- pytest 040.network-connectivity-checker/tests/test_check_network_connectivity.py (40 passed)
- Manual run succeeded:
  - python scripts/check_network_connectivity.py --provider gcp --resource-type cloudrun --resource-id " projects/sandbox-493008/locations/asia-northeast1/services/ncc-test-cloudrun\
