### PR TITLE
feat(040): add ELBv2 reverse lookup to EC2 connectivity check

### DIFF
--- a/040.network-connectivity-checker/README.md
+++ b/040.network-connectivity-checker/README.md
@@ -51,7 +51,7 @@
 
 | リソース | 必要な IAM アクション |
 |---------|---------------------|
-| EC2 | `ec2:DescribeInstances` `ec2:DescribeSecurityGroups` `ec2:DescribeRouteTables` `ec2:DescribeSubnets` |
+| EC2 | `ec2:DescribeInstances` `ec2:DescribeSecurityGroups` `ec2:DescribeRouteTables` `ec2:DescribeSubnets` `elasticloadbalancing:DescribeTargetGroups` `elasticloadbalancing:DescribeTargetHealth` `elasticloadbalancing:DescribeLoadBalancers` |
 | RDS | `rds:DescribeDBInstances` `ec2:DescribeSecurityGroups` |
 
 最小権限ポリシー例（AWS マネージドポリシー）:

--- a/040.network-connectivity-checker/aws.tf
+++ b/040.network-connectivity-checker/aws.tf
@@ -188,6 +188,124 @@ resource "aws_instance" "test" {
   }
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ALB（internet-facing）: EC2 をターゲットにしたテスト用 ALB
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- Subnet（ALB 用セカンダリパブリック: 別 AZ が必要）---
+
+resource "aws_subnet" "public_secondary" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.3.0/24"
+  availability_zone       = "${var.aws_region}c"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.project_name}-public-secondary-subnet"
+    Tier = "public"
+  }
+}
+
+resource "aws_route_table_association" "public_secondary" {
+  subnet_id      = aws_subnet.public_secondary.id
+  route_table_id = aws_route_table.public.id
+}
+
+# --- Security Group（ALB 用: 実行元グローバル IP からの HTTP のみ許可）---
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "Security group for integration test ALB"
+  vpc_id      = aws_vpc.main.id
+
+  # HTTP 許可（実行元 IP からのみ: integration test 専用）
+  # tfsec:ignore:aws-ec2-no-public-ingress-sgr
+  ingress {
+    description = "Allow HTTP from caller IP - integration test only, not for production use"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [local.allowed_cidr]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-alb-sg"
+  }
+}
+
+# --- Target Group（EC2 インスタンスをターゲットに登録）---
+
+resource "aws_lb_target_group" "ec2" {
+  name     = "${var.project_name}-ec2-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  target_type = "instance"
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+  }
+
+  tags = {
+    Name = "${var.project_name}-ec2-tg"
+  }
+}
+
+resource "aws_lb_target_group_attachment" "ec2" {
+  target_group_arn = aws_lb_target_group.ec2.arn
+  target_id        = aws_instance.test.id
+  port             = 80
+}
+
+# --- ALB（internet-facing）---
+
+resource "aws_lb" "test_internet_facing" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public.id, aws_subnet.public_secondary.id]
+
+  depends_on = [
+    aws_internet_gateway.main,
+    aws_route_table_association.public,
+    aws_route_table_association.public_secondary,
+  ]
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name = "${var.project_name}-alb"
+  }
+}
+
+# --- Listener（HTTP:80 → EC2 Target Group）---
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.test_internet_facing.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ec2.arn
+  }
+}
+
 # --- DB Subnet Group（RDS 用マルチ AZ サブネットグループ）---
 
 resource "aws_db_subnet_group" "main" {

--- a/040.network-connectivity-checker/outputs.tf
+++ b/040.network-connectivity-checker/outputs.tf
@@ -29,6 +29,16 @@ output "aws_rds_endpoint" {
   value       = aws_db_instance.test.endpoint
 }
 
+output "aws_alb_arn" {
+  description = "テスト用 ALB ARN"
+  value       = aws_lb.test_internet_facing.arn
+}
+
+output "aws_alb_dns_name" {
+  description = "テスト用 ALB の DNS 名"
+  value       = aws_lb.test_internet_facing.dns_name
+}
+
 output "aws_vpc_id" {
   description = "AWS VPC ID"
   value       = aws_vpc.main.id

--- a/040.network-connectivity-checker/sample_output/aws_ec2_sample.json
+++ b/040.network-connectivity-checker/sample_output/aws_ec2_sample.json
@@ -20,6 +20,7 @@
     "private_ip": "10.0.1.10",
     "public_ip": "203.0.113.10",
     "public_ip_assigned": true,
+    "load_balancers": [],
     "security_groups": [
       {
         "group_id": "sg-0abc1234567890def",

--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -226,6 +226,52 @@ def _has_nat_route(ec2_client, subnet_id: str) -> bool:
     return False
 
 
+def _find_ec2_load_balancers(elbv2_client, instance_id: str) -> List[Dict[str, str]]:
+    """
+    Find ELBv2 (ALB/NLB) load balancers that have the given EC2 instance as a
+    registered target.
+
+    Performs a reverse lookup:
+      EC2 instance → Target Groups (TargetType=instance) → Load Balancers
+
+    Returns a list of dicts with "name" and "scheme" keys
+    (e.g. [{"name": "my-alb", "scheme": "internet-facing"}]).
+    """
+    lb_arns: Set[str] = set()
+    paginator_kwargs: Dict[str, Any] = {}
+
+    while True:
+        resp = elbv2_client.describe_target_groups(**paginator_kwargs)
+        for tg in resp.get("TargetGroups", []):
+            if tg.get("TargetType") != "instance":
+                continue
+            tg_arn = tg.get("TargetGroupArn", "")
+            if not tg_arn:
+                continue
+            health_resp = elbv2_client.describe_target_health(TargetGroupArn=tg_arn)
+            for desc in health_resp.get("TargetHealthDescriptions", []):
+                if desc.get("Target", {}).get("Id") == instance_id:
+                    for arn in tg.get("LoadBalancerArns", []):
+                        lb_arns.add(arn)
+                    break
+        next_marker = resp.get("NextMarker")
+        if not next_marker:
+            break
+        paginator_kwargs = {"Marker": next_marker}
+
+    if not lb_arns:
+        return []
+
+    lb_resp = elbv2_client.describe_load_balancers(LoadBalancerArns=list(lb_arns))
+    result: List[Dict[str, str]] = []
+    for lb in lb_resp.get("LoadBalancers", []):
+        name = lb.get("LoadBalancerName", "")
+        scheme = lb.get("Scheme", "")
+        if name:
+            result.append({"name": name, "scheme": scheme})
+    return result
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # AWS EC2
 # ─────────────────────────────────────────────────────────────────────────────
@@ -233,6 +279,7 @@ def _has_nat_route(ec2_client, subnet_id: str) -> bool:
 def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, Any]:
     """Check network reachability for an AWS EC2 instance."""
     ec2 = _get_boto3_client("ec2", region)
+    elbv2 = _get_boto3_client("elbv2", region)
 
     resp = ec2.describe_instances(InstanceIds=[resource_id])
     reservations = resp.get("Reservations", [])
@@ -256,6 +303,10 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
     nat_route = _has_nat_route(ec2, subnet_id) if subnet_id else False
     public_ip_assigned = bool(public_ip)
 
+    # Load balancers (ELBv2) associated with this instance
+    load_balancers = _find_ec2_load_balancers(elbv2, resource_id)
+    has_internet_facing_lb = any(lb["scheme"] == "internet-facing" for lb in load_balancers)
+
     reasons: List[str] = []
     observed: Dict[str, Any] = {
         "instance_state": instance_state,
@@ -266,6 +317,7 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
         "public_ip": public_ip or None,
         "public_ip_assigned": public_ip_assigned,
         "security_groups": [_sg_observed(sg) for sg in sgs],
+        "load_balancers": load_balancers,
     }
 
     # ── Reasons ──────────────────────────────────────────────────────────────
@@ -273,6 +325,7 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
     reasons.append(f"public_subnet={str(public_subnet).lower()}")
     reasons.append(f"nat_route={str(nat_route).lower()}")
     reasons.append(f"public_ip_assigned={str(public_ip_assigned).lower()}")
+    reasons.append(f"lb_internet_facing={str(has_internet_facing_lb).lower()}")
     if ingress_cidrs:
         reasons.append(f"sg_ingress_allows={','.join(sorted(set(ingress_cidrs)))}")
     if egress_cidrs:
@@ -281,9 +334,10 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
     # ── Reachability judgement ────────────────────────────────────────────────
     running = instance_state == "running"
 
-    # Internet reachability: instance must be running, in a public subnet
-    # (or have a public IP directly reachable), and have a public IP assigned.
-    if running and public_ip_assigned and public_subnet:
+    # Internet reachability: instance must be running, and either
+    # (a) in a public subnet with a public IP assigned, or
+    # (b) registered as a target of an internet-facing ELBv2 load balancer.
+    if running and (public_ip_assigned and public_subnet or has_internet_facing_lb):
         internet_reachability = REACHABLE
     elif not running:
         internet_reachability = NOT_REACHABLE

--- a/040.network-connectivity-checker/tests/test_check_network_connectivity.py
+++ b/040.network-connectivity-checker/tests/test_check_network_connectivity.py
@@ -232,7 +232,40 @@ class TestAwsEc2:
         client.describe_route_tables.return_value = {
             "RouteTables": [{"Routes": rt_routes}]
         }
+        # elbv2: no LBs by default (same client object is returned for both "ec2" and "elbv2")
+        client.describe_target_groups.return_value = {"TargetGroups": []}
         return client
+
+    def _mock_elbv2_client(self, load_balancers):
+        """
+        Build a mock elbv2 client that simulates a single target group
+        containing all given instance targets.
+
+        load_balancers: list of dicts with keys "name", "scheme", "arn"
+        """
+        elbv2 = MagicMock()
+        lb_arns = [lb["arn"] for lb in load_balancers]
+        elbv2.describe_target_groups.return_value = {
+            "TargetGroups": [
+                {
+                    "TargetGroupArn": "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:targetgroup/test-tg/abc123",
+                    "TargetType": "instance",
+                    "LoadBalancerArns": lb_arns,
+                }
+            ]
+        }
+        elbv2.describe_target_health.return_value = {
+            "TargetHealthDescriptions": [
+                {"Target": {"Id": "i-private", "Port": 80}}
+            ]
+        }
+        elbv2.describe_load_balancers.return_value = {
+            "LoadBalancers": [
+                {"LoadBalancerName": lb["name"], "Scheme": lb["scheme"]}
+                for lb in load_balancers
+            ]
+        }
+        return elbv2
 
     @patch("check_network_connectivity._get_boto3_client")
     def test_running_public_instance_is_reachable(self, mock_client):
@@ -326,6 +359,79 @@ class TestAwsEc2:
         assert observed_sg["ingress_rules"][0]["protocol"] == "tcp"
         assert observed_sg["ingress_rules"][0]["from_port"] == 443
         assert observed_sg["ingress_rules"][0]["to_port"] == 443
+        assert "load_balancers" in result["observed"]
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_private_instance_with_internet_facing_alb_is_reachable(self, mock_client):
+        """EC2 in private subnet, no public IP, but registered to an internet-facing ALB → reachable."""
+        instance = _make_ec2_instance(public_ip="")
+        sg = _make_sg()
+
+        ec2_client = self._mock_ec2_client(instance, sg, public_subnet=False)
+        elbv2_client = self._mock_elbv2_client([
+            {"name": "my-alb", "scheme": "internet-facing", "arn": "arn:aws:elasticloadbalancing:ap-northeast-1:123:loadbalancer/app/my-alb/abc"}
+        ])
+        # Patch the health check to match the instance id used in the test
+        elbv2_client.describe_target_health.return_value = {
+            "TargetHealthDescriptions": [{"Target": {"Id": "i-private", "Port": 80}}]
+        }
+        # Override target group to reference the instance id from _make_ec2_instance (no id field,
+        # use "i-private" which is the id we pass to check_aws_ec2 below)
+
+        mock_client.side_effect = lambda svc, region=None: (
+            elbv2_client if svc == "elbv2" else ec2_client
+        )
+
+        result = cnc.check_aws_ec2("i-private")
+
+        assert result["internet_reachability"] == cnc.REACHABLE
+        assert result["private_reachability"] == cnc.REACHABLE
+        assert "lb_internet_facing=true" in result["reasons"]
+        assert result["observed"]["load_balancers"] == [{"name": "my-alb", "scheme": "internet-facing"}]
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_private_instance_with_internal_alb_not_internet_reachable(self, mock_client):
+        """EC2 in private subnet, no public IP, only internal ALB → not internet reachable."""
+        instance = _make_ec2_instance(public_ip="")
+        sg = _make_sg()
+
+        ec2_client = self._mock_ec2_client(instance, sg, public_subnet=False)
+        elbv2_client = self._mock_elbv2_client([
+            {"name": "my-internal-alb", "scheme": "internal", "arn": "arn:aws:elasticloadbalancing:ap-northeast-1:123:loadbalancer/app/my-internal-alb/def"}
+        ])
+        elbv2_client.describe_target_health.return_value = {
+            "TargetHealthDescriptions": [{"Target": {"Id": "i-private-internal", "Port": 80}}]
+        }
+
+        mock_client.side_effect = lambda svc, region=None: (
+            elbv2_client if svc == "elbv2" else ec2_client
+        )
+
+        result = cnc.check_aws_ec2("i-private-internal")
+
+        assert result["internet_reachability"] == cnc.NOT_REACHABLE
+        assert result["private_reachability"] == cnc.REACHABLE
+        assert "lb_internet_facing=false" in result["reasons"]
+        assert result["observed"]["load_balancers"] == [{"name": "my-internal-alb", "scheme": "internal"}]
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_no_lb_behavior_unchanged(self, mock_client):
+        """No LB → internet_reachability depends solely on public IP + public subnet (unchanged)."""
+        instance = _make_ec2_instance()
+        sg = _make_sg()
+        ec2_client = self._mock_ec2_client(instance, sg, public_subnet=True)
+        elbv2_client = MagicMock()
+        elbv2_client.describe_target_groups.return_value = {"TargetGroups": []}
+
+        mock_client.side_effect = lambda svc, region=None: (
+            elbv2_client if svc == "elbv2" else ec2_client
+        )
+
+        result = cnc.check_aws_ec2("i-nolb")
+
+        assert result["internet_reachability"] == cnc.REACHABLE
+        assert "lb_internet_facing=false" in result["reasons"]
+        assert result["observed"]["load_balancers"] == []
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1067,6 +1173,7 @@ class TestJsonSerializable:
         client.describe_route_tables.return_value = {
             "RouteTables": [{"Routes": [{"GatewayId": "igw-x", "DestinationCidrBlock": "0.0.0.0/0"}]}]
         }
+        client.describe_target_groups.return_value = {"TargetGroups": []}
         mock_client.return_value = client
 
         result = cnc.check_aws_ec2("i-json")


### PR DESCRIPTION
## 概要

`040.network-connectivity-checker` の EC2 チェック処理に、ELBv2 (ALB/NLB) 逆引きロジックを追加しました。  
EC2 インスタンスに internet-facing なロードバランサーが紐づいている場合、パブリック IP がなくてもインターネット到達可能と判定するようになります。

## 変更内容

### スクリプト (`scripts/check_network_connectivity.py`)
- `_find_ec2_load_balancers(elbv2_client, instance_id)` 関数を追加
  - TargetGroup 全件を取得し、対象インスタンスに紐づく LB を逆引き
  - 戻り値: `[{"name": "...", "scheme": "internet-facing|internal"}]`
- `check_aws_ec2()` を更新
  - ELBv2 クライアントを生成し LB 逆引きを実行
  - `observed.load_balancers` に結果を格納
  - `reasons.lb_internet_facing` を追加
  - internet_reachability 判定に `has_internet_facing_lb` 条件を追加

### テスト (`tests/test_check_network_connectivity.py`)
- 新テストケース 3 件追加 (`TestAwsEc2`)
  - private subnet + internet-facing ALB → `reachable`
  - private subnet + internal ALB のみ → `not_reachable`
  - LB なし → 既存動作と同じ
- 既存テストの `describe_target_groups` モック追加（無限ループバグ修正）
- 合計 46 tests all passing

### Terraform (`aws.tf`, `outputs.tf`)
- セカンダリパブリックサブネット (`10.0.3.0/24`) 追加
- ALB 用セキュリティグループ追加（インバウンドは実行元 IP のみ許可）
- ターゲットグループ・ターゲット登録・ALB・リスナーを追加
- ALB ARN・DNS 名を `outputs.tf` に追加

### ドキュメント・サンプル
- `README.md`: 必要 IAM アクションに ELB 権限 3 件を追記
- `sample_output/aws_ec2_sample.json`: `load_balancers` フィールドを追加
