### PR TITLE
feat(040): add --profile for AWS in network connectivity checker

### DIFF
--- a/040.network-connectivity-checker/README.md
+++ b/040.network-connectivity-checker/README.md
@@ -142,6 +142,7 @@ usage: check_network_connectivity.py [-h]
   --resource-id RESOURCE_ID
   [--region REGION]
   [--lb-backend-service LB_BACKEND_SERVICE]
+  [--profile PROFILE]
   [--output OUTPUT]
 ```
 
@@ -152,6 +153,7 @@ usage: check_network_connectivity.py [-h]
 | `--resource-id` | リソース識別子（種別ごとに異なる、後述） |
 | `--region` | AWS リージョン（省略時は環境変数 `AWS_DEFAULT_REGION` を参照） |
 | `--lb-backend-service` | GCP Cloud Run 判定時に、複数候補から絞り込む任意の Backend Service 名 |
+| `--profile` | **AWS のみ** 使用する名前付きプロファイル（省略時はデフォルト認証チェーンを使用） |
 | `--output` | JSON 出力先ファイルパス（省略時は標準出力） |
 
 ---
@@ -164,9 +166,18 @@ python scripts/check_network_connectivity.py \
   --resource-type ec2 \
   --resource-id i-0abc1234567890def \
   --region ap-northeast-1
+
+# AWS プロファイルを指定する場合
+python scripts/check_network_connectivity.py \
+  --provider aws \
+  --resource-type ec2 \
+  --resource-id i-0abc1234567890def \
+  --region ap-northeast-1 \
+  --profile myprofile
 ```
 
-**`--resource-id`**: EC2 インスタンス ID（例: `i-0abc1234567890def`）
+**`--resource-id`**: EC2 インスタンス ID（例: `i-0abc1234567890def`）  
+**`--profile`**: AWS CLI で設定した名前付きプロファイル名（省略可）
 
 ---
 
@@ -178,9 +189,18 @@ python scripts/check_network_connectivity.py \
   --resource-type rds \
   --resource-id mydbinstance \
   --region ap-northeast-1
+
+# AWS プロファイルを指定する場合
+python scripts/check_network_connectivity.py \
+  --provider aws \
+  --resource-type rds \
+  --resource-id mydbinstance \
+  --region ap-northeast-1 \
+  --profile myprofile
 ```
 
-**`--resource-id`**: DB インスタンス識別子（例: `mydbinstance`）
+**`--resource-id`**: DB インスタンス識別子（例: `mydbinstance`）  
+**`--profile`**: AWS CLI で設定した名前付きプロファイル名（省略可）
 
 ---
 

--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -62,7 +62,7 @@ def _build_result(
 # AWS helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _get_boto3_client(service: str, region: Optional[str] = None):
+def _get_boto3_client(service: str, region: Optional[str] = None, profile: Optional[str] = None):
     """Return a boto3 client, importing boto3 lazily."""
     try:
         import boto3  # type: ignore
@@ -71,6 +71,9 @@ def _get_boto3_client(service: str, region: Optional[str] = None):
     kwargs: Dict[str, Any] = {}
     if region:
         kwargs["region_name"] = region
+    if profile:
+        session = boto3.Session(profile_name=profile)
+        return session.client(service, **kwargs)
     return boto3.client(service, **kwargs)
 
 
@@ -276,10 +279,10 @@ def _find_ec2_load_balancers(elbv2_client, instance_id: str) -> List[Dict[str, s
 # AWS EC2
 # ─────────────────────────────────────────────────────────────────────────────
 
-def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, Any]:
+def check_aws_ec2(resource_id: str, region: Optional[str] = None, profile: Optional[str] = None) -> Dict[str, Any]:
     """Check network reachability for an AWS EC2 instance."""
-    ec2 = _get_boto3_client("ec2", region)
-    elbv2 = _get_boto3_client("elbv2", region)
+    ec2 = _get_boto3_client("ec2", region, profile)
+    elbv2 = _get_boto3_client("elbv2", region, profile)
 
     resp = ec2.describe_instances(InstanceIds=[resource_id])
     reservations = resp.get("Reservations", [])
@@ -367,10 +370,10 @@ def check_aws_ec2(resource_id: str, region: Optional[str] = None) -> Dict[str, A
 # AWS RDS
 # ─────────────────────────────────────────────────────────────────────────────
 
-def check_aws_rds(resource_id: str, region: Optional[str] = None) -> Dict[str, Any]:
+def check_aws_rds(resource_id: str, region: Optional[str] = None, profile: Optional[str] = None) -> Dict[str, Any]:
     """Check network reachability for an AWS RDS DB instance."""
-    rds = _get_boto3_client("rds", region)
-    ec2 = _get_boto3_client("ec2", region)
+    rds = _get_boto3_client("rds", region, profile)
+    ec2 = _get_boto3_client("ec2", region, profile)
 
     resp = rds.describe_db_instances(DBInstanceIdentifier=resource_id)
     instances = resp.get("DBInstances", [])
@@ -1381,6 +1384,7 @@ def check(
     resource_id: str,
     region: Optional[str] = None,
     lb_backend_service: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Main entry point.  Dispatches to the appropriate provider/resource-type
@@ -1393,8 +1397,8 @@ def check(
             f"Supported: {', '.join(f'{p}/{r}' for p, r in SUPPORTED)}"
         )
     func = SUPPORTED[key]
-    if region and key in {("aws", "ec2"), ("aws", "rds")}:
-        return func(resource_id, region=region)
+    if key in {("aws", "ec2"), ("aws", "rds")}:
+        return func(resource_id, region=region, profile=profile)
     if key == ("gcp", "cloudrun"):
         return func(resource_id, lb_backend_service=lb_backend_service)
     return func(resource_id)
@@ -1438,6 +1442,11 @@ def main() -> None:
         help="Optional backend service name to disambiguate LB lookup for GCP Cloud Run",
     )
     parser.add_argument(
+        "--profile",
+        default=None,
+        help="AWS named profile to use (aws provider only). Overrides default credential chain.",
+    )
+    parser.add_argument(
         "--output",
         default=None,
         help="Write JSON output to this file instead of stdout",
@@ -1452,6 +1461,7 @@ def main() -> None:
             resource_id=args.resource_id,
             region=args.region,
             lb_backend_service=args.lb_backend_service,
+            profile=args.profile,
         )
         output = json.dumps(result, indent=2, ensure_ascii=False)
         if args.output:

--- a/040.network-connectivity-checker/tests/test_check_network_connectivity.py
+++ b/040.network-connectivity-checker/tests/test_check_network_connectivity.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Unit tests for check_network_connectivity.py
 
 All external API calls (boto3, Azure SDK, GCP API) are mocked so that these
@@ -16,9 +16,9 @@ import pytest
 import check_network_connectivity as cnc
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # Helper factories
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 def _make_ec2_instance(
     state="running",
@@ -65,9 +65,9 @@ def _make_sg(group_id="sg-111", ingress_cidrs=None, egress_cidrs=None):
     }
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # Utility / helper tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestBuildResult:
     """Tests for _build_result helper."""
@@ -188,9 +188,9 @@ class TestParseGcpResourceId:
         assert parsed["instances"] == "my-db"
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # Dispatcher tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestDispatcher:
     def test_unsupported_combination_raises(self):
@@ -206,9 +206,9 @@ class TestDispatcher:
         assert ("gcp", "cloudsql") in cnc.SUPPORTED
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # AWS EC2 tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestAwsEc2:
     """Tests for check_aws_ec2."""
@@ -363,7 +363,7 @@ class TestAwsEc2:
 
     @patch("check_network_connectivity._get_boto3_client")
     def test_private_instance_with_internet_facing_alb_is_reachable(self, mock_client):
-        """EC2 in private subnet, no public IP, but registered to an internet-facing ALB → reachable."""
+        """EC2 in private subnet, no public IP, but registered to an internet-facing ALB 竊・reachable."""
         instance = _make_ec2_instance(public_ip="")
         sg = _make_sg()
 
@@ -378,7 +378,7 @@ class TestAwsEc2:
         # Override target group to reference the instance id from _make_ec2_instance (no id field,
         # use "i-private" which is the id we pass to check_aws_ec2 below)
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             elbv2_client if svc == "elbv2" else ec2_client
         )
 
@@ -391,7 +391,7 @@ class TestAwsEc2:
 
     @patch("check_network_connectivity._get_boto3_client")
     def test_private_instance_with_internal_alb_not_internet_reachable(self, mock_client):
-        """EC2 in private subnet, no public IP, only internal ALB → not internet reachable."""
+        """EC2 in private subnet, no public IP, only internal ALB 竊・not internet reachable."""
         instance = _make_ec2_instance(public_ip="")
         sg = _make_sg()
 
@@ -403,7 +403,7 @@ class TestAwsEc2:
             "TargetHealthDescriptions": [{"Target": {"Id": "i-private-internal", "Port": 80}}]
         }
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             elbv2_client if svc == "elbv2" else ec2_client
         )
 
@@ -416,14 +416,14 @@ class TestAwsEc2:
 
     @patch("check_network_connectivity._get_boto3_client")
     def test_no_lb_behavior_unchanged(self, mock_client):
-        """No LB → internet_reachability depends solely on public IP + public subnet (unchanged)."""
+        """No LB 竊・internet_reachability depends solely on public IP + public subnet (unchanged)."""
         instance = _make_ec2_instance()
         sg = _make_sg()
         ec2_client = self._mock_ec2_client(instance, sg, public_subnet=True)
         elbv2_client = MagicMock()
         elbv2_client.describe_target_groups.return_value = {"TargetGroups": []}
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             elbv2_client if svc == "elbv2" else ec2_client
         )
 
@@ -434,9 +434,9 @@ class TestAwsEc2:
         assert result["observed"]["load_balancers"] == []
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # AWS RDS tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestAwsRds:
     """Tests for check_aws_rds."""
@@ -475,7 +475,7 @@ class TestAwsRds:
         rds_client.describe_db_instances.return_value = {"DBInstances": [db]}
         ec2_client.describe_security_groups.return_value = {"SecurityGroups": [sg]}
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             rds_client if svc == "rds" else ec2_client
         )
 
@@ -496,7 +496,7 @@ class TestAwsRds:
         rds_client.describe_db_instances.return_value = {"DBInstances": [db]}
         ec2_client.describe_security_groups.return_value = {"SecurityGroups": [sg]}
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             rds_client if svc == "rds" else ec2_client
         )
 
@@ -515,7 +515,7 @@ class TestAwsRds:
         rds_client.describe_db_instances.return_value = {"DBInstances": [db]}
         ec2_client.describe_security_groups.return_value = {"SecurityGroups": [sg]}
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             rds_client if svc == "rds" else ec2_client
         )
 
@@ -543,7 +543,7 @@ class TestAwsRds:
         rds_client.describe_db_instances.return_value = {"DBInstances": [db]}
         ec2_client.describe_security_groups.return_value = {"SecurityGroups": [sg]}
 
-        mock_client.side_effect = lambda svc, region=None: (
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
             rds_client if svc == "rds" else ec2_client
         )
 
@@ -563,9 +563,9 @@ class TestAwsRds:
         assert observed_sg["ingress_rules"][0]["to_port"] == 443
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # Azure VM tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestAzureVm:
     """Tests for check_azure_vm."""
@@ -749,9 +749,9 @@ class TestAzureVm:
             cnc.check_azure_vm("just-a-vm-name")
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # GCP Compute Engine tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestGcpCompute:
     """Tests for check_gcp_compute."""
@@ -872,9 +872,9 @@ class TestGcpCompute:
         assert "external_ip_assigned=false" in result["reasons"]
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # GCP Cloud Run tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestGcpCloudRun:
     """Tests for check_gcp_cloudrun."""
@@ -1049,9 +1049,9 @@ class TestGcpCloudRun:
         assert sorted(result["observed"]["matched_lb_names"]) == ["fw-external", "fw-internal"]
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # GCP Cloud SQL tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestGcpCloudSql:
     """Tests for check_gcp_cloudsql."""
@@ -1156,9 +1156,9 @@ class TestGcpCloudSql:
         assert "authorized_networks" in result["observed"]
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 # JSON serialisability tests
-# ─────────────────────────────────────────────────────────────────────────────
+# 笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏笏
 
 class TestJsonSerializable:
     """Verify result dicts can be serialised to JSON without errors."""
@@ -1180,3 +1180,112 @@ class TestJsonSerializable:
         serialised = json.dumps(result)
         parsed = json.loads(serialised)
         assert parsed["provider"] == "aws"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AWS profile option tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAwsProfile:
+    """Verify that --profile is propagated to _get_boto3_client."""
+
+    def _mock_ec2_client(self, instance, sg):
+        client = MagicMock()
+        client.describe_instances.return_value = {"Reservations": [{"Instances": [instance]}]}
+        client.describe_security_groups.return_value = {"SecurityGroups": [sg]}
+        client.describe_route_tables.return_value = {
+            "RouteTables": [{"Routes": [{"GatewayId": "igw-x", "DestinationCidrBlock": "0.0.0.0/0"}]}]
+        }
+        client.describe_target_groups.return_value = {"TargetGroups": []}
+        return client
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_ec2_profile_passed_to_client(self, mock_client):
+        instance = _make_ec2_instance()
+        sg = _make_sg()
+        client = self._mock_ec2_client(instance, sg)
+        mock_client.return_value = client
+
+        cnc.check_aws_ec2("i-123", profile="my-profile")
+
+        calls = mock_client.call_args_list
+        assert all(call.args[2] == "my-profile" or call.kwargs.get("profile") == "my-profile" for call in calls)
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_ec2_no_profile_uses_default(self, mock_client):
+        instance = _make_ec2_instance()
+        sg = _make_sg()
+        client = self._mock_ec2_client(instance, sg)
+        mock_client.return_value = client
+
+        cnc.check_aws_ec2("i-123")
+
+        calls = mock_client.call_args_list
+        for call in calls:
+            profile_arg = call.args[2] if len(call.args) > 2 else call.kwargs.get("profile")
+            assert profile_arg is None
+
+    @patch("check_network_connectivity._get_boto3_client")
+    def test_rds_profile_passed_to_client(self, mock_client):
+        db = {
+            "DBInstanceStatus": "available",
+            "PubliclyAccessible": False,
+            "DBSubnetGroup": {
+                "VpcId": "vpc-111",
+                "DBSubnetGroupName": "sg-group",
+                "Subnets": [],
+            },
+            "VpcSecurityGroups": [],
+            "Endpoint": {"Address": "mydb.rds.amazonaws.com", "Port": 3306},
+        }
+        rds_client = MagicMock()
+        rds_client.describe_db_instances.return_value = {"DBInstances": [db]}
+        ec2_client = MagicMock()
+        ec2_client.describe_security_groups.return_value = {"SecurityGroups": []}
+        mock_client.side_effect = lambda svc, region=None, profile=None: (
+            rds_client if svc == "rds" else ec2_client
+        )
+
+        cnc.check_aws_rds("mydb", profile="my-profile")
+
+        calls = mock_client.call_args_list
+        assert all(call.args[2] == "my-profile" or call.kwargs.get("profile") == "my-profile" for call in calls)
+
+    def test_get_boto3_client_uses_session_when_profile_given(self):
+        """_get_boto3_client creates a boto3.Session when profile is specified."""
+        import unittest.mock as um
+        with um.patch("boto3.Session") as mock_session_cls, um.patch("boto3.client") as mock_direct_client:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            mock_session.client.return_value = MagicMock()
+
+            cnc._get_boto3_client("ec2", profile="my-profile")
+
+            mock_session_cls.assert_called_once_with(profile_name="my-profile")
+            mock_session.client.assert_called_once()
+            mock_direct_client.assert_not_called()
+
+    def test_get_boto3_client_uses_direct_client_without_profile(self):
+        """_get_boto3_client uses boto3.client directly when no profile is specified."""
+        import unittest.mock as um
+        with um.patch("boto3.Session") as mock_session_cls, um.patch("boto3.client") as mock_direct_client:
+            mock_direct_client.return_value = MagicMock()
+
+            cnc._get_boto3_client("ec2")
+
+            mock_session_cls.assert_not_called()
+            mock_direct_client.assert_called_once()
+
+    def test_check_dispatcher_passes_profile_to_aws_ec2(self):
+        mock_fn = MagicMock(return_value={"result": "ok"})
+        with patch.dict(cnc.SUPPORTED, {("aws", "ec2"): mock_fn}):
+            cnc.check("aws", "ec2", "i-123", profile="my-profile")
+            mock_fn.assert_called_once_with("i-123", region=None, profile="my-profile")
+
+    def test_check_dispatcher_passes_profile_to_aws_rds(self):
+        mock_fn = MagicMock(return_value={"result": "ok"})
+        with patch.dict(cnc.SUPPORTED, {("aws", "rds"): mock_fn}):
+            cnc.check("aws", "rds", "mydb", region="us-east-1", profile="my-profile")
+            mock_fn.assert_called_once_with("mydb", region="us-east-1", profile="my-profile")
+
+


### PR DESCRIPTION
## 概要

`040.network-connectivity-checker` の CLI スクリプトに AWS 名前付きプロファイル (`--profile`) オプションを追加しました。

## 変更内容

### `scripts/check_network_connectivity.py`

- `_get_boto3_client()` に `profile` パラメータを追加
  - `profile` 指定時: `boto3.Session(profile_name=profile).client(...)` を使用
  - 未指定時: 従来どおり `boto3.client(...)` を直接使用
- `check_aws_ec2()` / `check_aws_rds()` に `profile: Optional[str] = None` を追加し、`_get_boto3_client()` へ伝播
- `check()` ディスパッチャに `profile: Optional[str] = None` を追加し、AWS リソース呼び出し時に渡す
- `main()` に `--profile` 引数を追加（AWS プロバイダのみ有効）

### `tests/test_check_network_connectivity.py`

- `TestAwsProfile` クラスを追加
  - `test_ec2_profile_passed_to_client`
  - `test_ec2_no_profile_uses_default`
  - `test_rds_profile_passed_to_client`
  - `test_get_boto3_client_uses_session_when_profile_given`
  - `test_get_boto3_client_uses_direct_client_without_profile`
  - `test_check_dispatcher_passes_profile_to_aws_ec2`
  - `test_check_dispatcher_passes_profile_to_aws_rds`

### `README.md`

- 使用例に `--profile` オプションを追加（AWS EC2 / AWS RDS セクション）
- オプション一覧テーブルに `--profile` 行を追加

## 使用例

```bash
python scripts/check_network_connectivity.py \
  --provider aws \
  --resource-type ec2 \
  --resource-id i-0abc1234567890def \
  --region ap-northeast-1 \
  --profile myprofile
```

## テスト

```
53 passed
```