### PR TITLE
fix(dependabot): group non-semver pip updates as others

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,9 @@ updates:
           - "*"
         update-types:
           - "major"
+      others:
+        patterns:
+          - "*"
   - package-ecosystem: terraform
     directories: 
       - "**/*"


### PR DESCRIPTION
## Summary
- add pip group others as a fallback group
- keep existing minor/patch and major grouping as-is

## Why
- ensure pip updates that do not match update-types are bundled into a single pull request

## Scope
- .github/dependabot.yml