### PR TITLE
chore: simplify dependabot terraform provider patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,51 +141,23 @@ updates:
           - "major"
       hashicorp-providers:
         patterns:
-          - "hashicorp/http"
-          - "hashicorp/null"
-          - "hashicorp/random"
-          - "hashicorp/local"
-          - "hashicorp/tls"
-          - "hashicorp/time"
+          - "hashicorp/*"
         update-types:
           - "minor"
           - "patch"
       hashicorp-providers-major:
         patterns:
-          - "hashicorp/http"
-          - "hashicorp/null"
-          - "hashicorp/random"
-          - "hashicorp/local"
-          - "hashicorp/tls"
-          - "hashicorp/time"
+          - "hashicorp/*"
         update-types:
           - "major"
       other-providers:
         patterns:
           - "*"
-        exclude-patterns:
-          - "hashicorp/aws"
-          - "oracle/oci"
-          - "hashicorp/http"
-          - "hashicorp/null"
-          - "hashicorp/random"
-          - "hashicorp/local"
-          - "hashicorp/tls"
-          - "hashicorp/time"
         update-types:
           - "minor"
           - "patch"
       other-providers-major:
         patterns:
           - "*"
-        exclude-patterns:
-          - "hashicorp/aws"
-          - "oracle/oci"
-          - "hashicorp/http"
-          - "hashicorp/null"
-          - "hashicorp/random"
-          - "hashicorp/local"
-          - "hashicorp/tls"
-          - "hashicorp/time"
         update-types:
           - "major"


### PR DESCRIPTION
## Summary
- simplify Terraform provider grouping in `.github/dependabot.yml`
- replace explicit `hashicorp/http|null|random|local|tls|time` lists with `hashicorp/*`
- remove now-unnecessary `exclude-patterns` blocks from `other-providers` groups

## Why
- reduce maintenance overhead when hashicorp providers are added/renamed
- keep update grouping behavior consistent with less config duplication

## Changes
- 1 file changed
- 2 insertions, 30 deletions