### PR TITLE
Pin requirements versions in 023, 030, and 035

### DIFF
--- a/023.bedrock-rag-agent-in-slack/scripts/requirements.txt
+++ b/023.bedrock-rag-agent-in-slack/scripts/requirements.txt
@@ -1,3 +1,3 @@
-boto3>=1.43.0
-botocore>=1.43.0
-requests>=2.33.1
+boto3==1.43.0
+botocore==1.43.0
+requests==2.33.1

--- a/030.apigateway-cognito-lambda-payload/scripts/requirements.txt
+++ b/030.apigateway-cognito-lambda-payload/scripts/requirements.txt
@@ -1,4 +1,4 @@
 # Python dependencies for the test script
-requests>=2.33.1
-boto3>=1.43.0
-botocore>=1.43.0
+requests==2.33.1
+boto3==1.43.0
+botocore==1.43.0

--- a/035.aurora-mock-testing/requirements.txt
+++ b/035.aurora-mock-testing/requirements.txt
@@ -1,23 +1,23 @@
 # AWS SDK
-boto3>=1.43.0
-botocore>=1.43.0
+boto3==1.43.0
+botocore==1.43.0
 
 # Database connectivity
-psycopg2-binary>=2.9.12
+psycopg2-binary==2.9.12
 
 # Web framework and HTTP client
-Flask>=3.1.3
-requests>=2.33.1
+Flask==3.1.3
+requests==2.33.1
 
 # Testing dependencies
-pytest>=9.0.3
-pytest-mock>=3.15.1
-moto>=5.1.22
+pytest==9.0.3
+pytest-mock==3.15.1
+moto==5.1.22
 
 # Development dependencies
-black>=26.3.1
-flake8>=7.3.0
-mypy>=1.20.2
+black==26.3.1
+flake8==7.3.0
+mypy==1.20.2
 
 # Type hints
-types-requests>=2.33.0.20260408
+types-requests==2.33.0.20260408


### PR DESCRIPTION
## Summary
- Replace all `>=` specifiers with `==` in these requirements files:
  - `023.bedrock-rag-agent-in-slack/scripts/requirements.txt`
  - `030.apigateway-cognito-lambda-payload/scripts/requirements.txt`
  - `035.aurora-mock-testing/requirements.txt`

## Purpose
- Pin dependency versions for reproducible installs and consistent behavior across environments.