### PR TITLE
Fix: Change version specifiers from >= to == in requirements.txt

### DIFF
--- a/034.redmine-mcp-server/scripts/requirements.txt
+++ b/034.redmine-mcp-server/scripts/requirements.txt
@@ -1,12 +1,12 @@
-mcp>=1.27.0
-selenium>=4.43.0
-webdriver-manager>=4.0.2
-pydantic>=2.13.3
-typing-extensions>=4.15.0
-python-dotenv>=1.2.2
+mcp==1.27.0
+selenium==4.43.0
+webdriver-manager==4.0.2
+pydantic==2.13.3
+typing-extensions==4.15.0
+python-dotenv==1.2.2
 
 # Test dependencies
-pytest>=9.0.3
-pytest-cov>=7.1.0
-pytest-asyncio>=1.3.0
-pytest-mock>=3.15.1
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-asyncio==1.3.0
+pytest-mock==3.15.1


### PR DESCRIPTION
Update 034.redmine-mcp-server/scripts/requirements.txt to use exact version pinning (==) instead of minimum version specifiers (>=).

This ensures reproducible builds with exact dependency versions.