### PR TITLE
chore: add dependabot group-by dependency-name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,17 +36,20 @@ updates:
       other-npm:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "minor"
           - "patch"
       other-npm-major:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "major"
       others:
         patterns:
           - "*"
+        group-by: "dependency-name"
   - package-ecosystem: "pip"
     directories:
       - "**/*"
@@ -65,17 +68,20 @@ updates:
       all-pip:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "minor"
           - "patch"
       all-pip-major:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "major"
       others:
         patterns:
           - "*"
+        group-by: "dependency-name"
   - package-ecosystem: terraform
     directories: 
       - "**/*"
@@ -92,14 +98,17 @@ updates:
       other-providers:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "minor"
           - "patch"
       other-providers-major:
         patterns:
           - "*"
+        group-by: "dependency-name"
         update-types:
           - "major"
       others:
         patterns:
           - "*"
+        group-by: "dependency-name"


### PR DESCRIPTION
## Summary
- add `group-by: "dependency-name"` to Dependabot groups for `npm`, `pip`, and `terraform`
- enable cross-directory grouping by dependency name for monorepo-style updates

## Why
- reduce one-off Dependabot PRs when the same dependency appears in multiple directories
- keep update PRs more consolidated and easier to review