### PR TITLE
feat: Add support for multiple source addresses in Azure NSG rules

### DIFF
--- a/040.network-connectivity-checker/azure.tf
+++ b/040.network-connectivity-checker/azure.tf
@@ -102,15 +102,15 @@ resource "azurerm_network_security_group" "main" {
   # 複数の送信元IP許可（複数アドレスパターンをテストするためのルール）
   # source_address_prefixes を使用して複数のCIDRブロックを許可
   security_rule {
-    name                        = "AllowMultipleSources"
-    priority                    = 130
-    direction                   = "Inbound"
-    access                      = "Allow"
-    protocol                    = "Tcp"
-    source_port_range           = "*"
-    destination_port_range      = "3306"
-    source_address_prefixes     = ["10.0.0.0/24", "192.168.1.0/24", "203.0.113.0/24"]
-    destination_address_prefix  = "*"
+    name                       = "AllowMultipleSources"
+    priority                   = 130
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "3306"
+    source_address_prefixes    = ["10.0.0.0/24", "192.168.1.0/24", "203.0.113.0/24"]
+    destination_address_prefix = "*"
   }
 
   tags = {

--- a/040.network-connectivity-checker/azure.tf
+++ b/040.network-connectivity-checker/azure.tf
@@ -99,6 +99,20 @@ resource "azurerm_network_security_group" "main" {
     destination_address_prefix = "*"
   }
 
+  # 複数の送信元IP許可（複数アドレスパターンをテストするためのルール）
+  # source_address_prefixes を使用して複数のCIDRブロックを許可
+  security_rule {
+    name                        = "AllowMultipleSources"
+    priority                    = 130
+    direction                   = "Inbound"
+    access                      = "Allow"
+    protocol                    = "Tcp"
+    source_port_range           = "*"
+    destination_port_range      = "3306"
+    source_address_prefixes     = ["10.0.0.0/24", "192.168.1.0/24", "203.0.113.0/24"]
+    destination_address_prefix  = "*"
+  }
+
   tags = {
     Name = "${var.project_name}-nsg"
   }

--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -480,7 +480,9 @@ def _azure_collect_allow_rules(nsg: Any) -> List[Dict[str, Any]]:
                     "priority": rule.priority,
                     "protocol": rule.protocol,
                     "source_address_prefix": rule.source_address_prefix or "",
+                    "source_address_prefixes": rule.source_address_prefixes or [],
                     "destination_address_prefix": rule.destination_address_prefix or "",
+                    "destination_address_prefixes": rule.destination_address_prefixes or [],
                     "destination_port_range": rule.destination_port_range or "",
                 }
             )


### PR DESCRIPTION
## 変更内容

### Python スクリプト (check_network_connectivity.py)
- `_azure_collect_allow_rules()` 関数を改修
- `source_address_prefixes`（複数の送信元アドレス）を取得するよう対応
- `destination_address_prefixes`（複数の宛先アドレス）も同時に対応

### Terraform (azure.tf)
- 複数のIPアドレスを許可する NSG ルール「AllowMultipleSources」を追加
  - ポート: 3306 (MySQL)
  - 許可元: `10.0.0.0/24`, `192.168.1.0/24`, `203.0.113.0/24` (RFC 5737 テスト用予約アドレス)
  
## 目的
Azure NSG ルールが複数の送信元・宛先アドレスを指定している場合に、完全に取得・表示できるようにしました。これにより、ネットワーク接続性チェッカーのテストカバレッジが向上します。