### PR TITLE
Add Azure VM LB reverse lookup and test LB resources

### DIFF
--- a/040.network-connectivity-checker/azure.tf
+++ b/040.network-connectivity-checker/azure.tf
@@ -1,3 +1,65 @@
+################################################################################
+# Azure Load Balancer (Standard, Public) テスト用リソース
+################################################################################
+
+resource "azurerm_public_ip" "lb" {
+  name                = "${var.project_name}-lb-pip"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = {
+    Name = "${var.project_name}-lb-pip"
+  }
+}
+
+resource "azurerm_lb" "test" {
+  name                = "${var.project_name}-lb"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "PublicLBFrontend"
+    public_ip_address_id = azurerm_public_ip.lb.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-lb"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "test-backend-pool"
+  loadbalancer_id     = azurerm_lb.test.id
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "vm" {
+  network_interface_id    = azurerm_network_interface.vm.id
+  ip_configuration_name   = "internal"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.test.id
+}
+
+# Health Probe (TCP 80)
+resource "azurerm_lb_probe" "test" {
+  name                = "test-probe"
+  loadbalancer_id     = azurerm_lb.test.id
+  protocol            = "Tcp"
+  port                = 80
+}
+
+# LB Rule (HTTP)
+resource "azurerm_lb_rule" "test" {
+  name                           = "test-lb-rule"
+  loadbalancer_id                = azurerm_lb.test.id
+  protocol                      = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 80
+  frontend_ip_configuration_name = "PublicLBFrontend"
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.test.id]
+  probe_id                       = azurerm_lb_probe.test.id
+}
 # ─────────────────────────────────────────────────────────────────────────────
 # Azure リソース: VNet / NSG / VM
 # ─────────────────────────────────────────────────────────────────────────────

--- a/040.network-connectivity-checker/azure.tf
+++ b/040.network-connectivity-checker/azure.tf
@@ -31,8 +31,8 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  name                = "test-backend-pool"
-  loadbalancer_id     = azurerm_lb.test.id
+  name            = "test-backend-pool"
+  loadbalancer_id = azurerm_lb.test.id
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "vm" {
@@ -43,17 +43,17 @@ resource "azurerm_network_interface_backend_address_pool_association" "vm" {
 
 # Health Probe (TCP 80)
 resource "azurerm_lb_probe" "test" {
-  name                = "test-probe"
-  loadbalancer_id     = azurerm_lb.test.id
-  protocol            = "Tcp"
-  port                = 80
+  name            = "test-probe"
+  loadbalancer_id = azurerm_lb.test.id
+  protocol        = "Tcp"
+  port            = 80
 }
 
 # LB Rule (HTTP)
 resource "azurerm_lb_rule" "test" {
   name                           = "test-lb-rule"
   loadbalancer_id                = azurerm_lb.test.id
-  protocol                      = "Tcp"
+  protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
   frontend_ip_configuration_name = "PublicLBFrontend"

--- a/040.network-connectivity-checker/scripts/check_network_connectivity.py
+++ b/040.network-connectivity-checker/scripts/check_network_connectivity.py
@@ -535,6 +535,10 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
     subnet_ids: List[str] = []
     has_udr = False
     seen_subnet_nsg_ids: set[str] = set()
+    # Azure LB逆引き用
+    nic_backend_pools: List[str] = []
+    lb_backend_pool_map: Dict[str, Dict[str, str]] = {}
+    lb_associations: List[Dict[str, str]] = []
 
     # Iterate NICs
     for nic_ref in vm.network_profile.network_interfaces or []:
@@ -593,6 +597,12 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
                 except Exception:
                     pass
 
+            # Azure LB: 逆引き用 (backend address pools)
+            if ip_config.load_balancer_backend_address_pools:
+                for pool in ip_config.load_balancer_backend_address_pools:
+                    if pool.id:
+                        nic_backend_pools.append(pool.id)
+
         # NSG on NIC
         if nic.network_security_group and nic.network_security_group.id:
             nsg_parts = _parse_azure_resource_id(nic.network_security_group.id)
@@ -605,6 +615,22 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
             except Exception:
                 pass
 
+    # Azure LB: 逆引き (LB名・プール名取得)
+    if nic_backend_pools:
+        lbs = list(network_client.load_balancers.list(resource_group_name=resource_group))
+        for lb in lbs:
+            for pool in lb.backend_address_pools or []:
+                if pool.id in nic_backend_pools:
+                    lb_backend_pool_map[pool.id] = {
+                        "lb_name": lb.name,
+                        "pool_name": pool.name,
+                        "lb_type": lb.sku.name if lb.sku else "Unknown",
+                        "frontend": ",".join([fip.name for fip in lb.frontend_ip_configurations or []]),
+                    }
+        for pool_id in nic_backend_pools:
+            if pool_id in lb_backend_pool_map:
+                lb_associations.append(lb_backend_pool_map[pool_id])
+
     reasons: List[str] = []
     observed: Dict[str, Any] = {
         "power_state": power_state,
@@ -614,6 +640,7 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
         "has_udr": has_udr,
         "nsg_rules": nsg_rules_info,
         "subnet_nsg_rules": subnet_nsg_rules_info,
+        "azure_lb_backend_pools": lb_associations,
     }
 
     reasons.append(f"power_state={power_state}")
@@ -623,6 +650,8 @@ def check_azure_vm(resource_id: str) -> Dict[str, Any]:
     reasons.append(f"nsg_rules_present_subnet={str(bool(subnet_nsg_rules_info)).lower()}")
     if nsg_rules_info or subnet_nsg_rules_info:
         reasons.append("nsg_rules_present=true")
+    if lb_associations:
+        reasons.append(f"azure_lb_backend_pools={','.join([f'{a['lb_name']}/{a['pool_name']}' for a in lb_associations])}")
 
     running = power_state.lower() == "running"
     has_public_ip = bool(public_ips)


### PR DESCRIPTION
## Summary
- Add reverse lookup for Azure VM -> Azure Load Balancer backend pool associations in network connectivity checker
- Include LB association details in `observed.azure_lb_backend_pools` and reasons output
- Add Azure test resources in Terraform (`azure.tf`): public Standard Load Balancer, backend pool, NIC association, probe, and LB rule
- Update Terraform arguments to match current AzureRM provider schema

## Validation
- `terraform init -backend=false`
- `terraform validate` (success)

## Changed files
- `040.network-connectivity-checker/scripts/check_network_connectivity.py`
- `040.network-connectivity-checker/azure.tf`