### PR TITLE
chore(042): split unit test workflows and auto-detect Python test targets

### DIFF
--- a/.github/skills/unit-test-spec/SKILL.md
+++ b/.github/skills/unit-test-spec/SKILL.md
@@ -78,3 +78,78 @@ description: '単体テストの仕様書・テストケースを作成する。
 - **ブラウザ・ネットワーク・ファイル I/O を使う関数** はモックが必要なため、テストケース表にモック対象を明記する
 - テストケース ID は README.md 内で一意になるよう連番を引き継ぐ
 - 実装コードを書くのではなく、仕様書（テストケース表）の生成のみを行う
+
+---
+
+## 単体テスト実行コマンド
+
+### Python (pytest)
+
+```bash
+pytest
+```
+
+```bash
+pytest -q
+```
+
+```bash
+pytest tests/test_xxx.py -v
+```
+
+### npm (Node.js)
+
+```bash
+npm test
+```
+
+```bash
+npm run test
+```
+
+```bash
+npm run test -- --watch
+```
+
+## 単体テスト/結合テストのコマンド分離
+
+### Python (pytest)
+
+- 単体テスト: `pytest -m unit`
+- 結合テスト: `pytest -m integration`
+- マーカー運用例（`pytest.ini`）
+
+```ini
+[pytest]
+markers =
+	unit: unit tests
+	integration: integration tests
+```
+
+### npm (Node.js)
+
+- 単体テスト: `npm run test:unit`
+- 結合テスト: `npm run test:integration`
+- `package.json` の script 名で分離して運用する
+
+## 単体テスト実行に必要なファイル
+
+### Python (pytest)
+
+- `pytest.ini` (必須): pytest の設定（探索パス、マーカー、オプション）
+- `tests/test_*.py`: 単体テストファイル
+- テスト対象のソースコード（例: `src/`, `scripts/` 配下）
+- `.env` / `.env.example` (必要な場合): 実行時に必要な環境変数
+- 依存関係定義はルートディレクトリの `requirements.txt` に統合済みのため、必要な場合はルートのファイルを参照する
+- `pyproject.toml` は単体テスト実行の必須条件にしない
+
+### npm (Node.js)
+
+- `package.json`: テストスクリプト（`test`）と依存関係定義
+- `package-lock.json` または `pnpm-lock.yaml` / `yarn.lock`: 依存固定ファイル
+- テストランナー設定ファイル（いずれか）
+	- `jest.config.js` / `jest.config.ts`
+	- `vitest.config.ts` / `vitest.config.js`
+	- `.mocharc.*`
+- テストファイル（例: `*.test.js`, `*.spec.ts`, `tests/` 配下）
+- テスト対象のソースコード（例: `src/` 配下）

--- a/.github/workflows/npm-unit-test.yml
+++ b/.github/workflows/npm-unit-test.yml
@@ -1,0 +1,38 @@
+name: npm Unit Test
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/npm-unit-test.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/npm-unit-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-unit-test:
+    name: npm Unit Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.github/workflows/npm-unit-test.yml
+++ b/.github/workflows/npm-unit-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -1,0 +1,72 @@
+name: Python Unit Test
+
+on:
+  pull_request:
+    paths:
+      - "**/pytest.ini"
+      - "**/tests/**/*.py"
+      - "**/scripts/**/*.py"
+      - "requirements.txt"
+      - ".github/workflows/python-unit-test.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/pytest.ini"
+      - "**/tests/**/*.py"
+      - "**/scripts/**/*.py"
+      - "requirements.txt"
+      - ".github/workflows/python-unit-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-unit-test:
+    name: Python Unit Test (Auto Detect)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Discover and run Python unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t dirs < <(find . -type f -name pytest.ini -not -path "*/.venv/*" -not -path "*/.pytest_cache/*" -exec dirname {} \; | sed 's#^./##' | sort -u)
+
+          if [ "${#dirs[@]}" -eq 0 ]; then
+            echo "No pytest.ini found. Skipping Python unit tests."
+            exit 0
+          fi
+
+          failed=0
+          for dir in "${dirs[@]}"; do
+            echo "==> Checking ${dir}"
+
+            if [ ! -d "${dir}/tests" ]; then
+              echo "No tests directory in ${dir}; skipped"
+              continue
+            fi
+
+            if ! grep -R -E "@pytest\.mark\.unit|\.mark\.unit" "${dir}/tests" --include='*.py' > /dev/null 2>&1; then
+              echo "No unit marker found in ${dir}/tests; skipped"
+              continue
+            fi
+
+            echo "Running pytest -m unit in ${dir}"
+            if ! (cd "${dir}" && pytest -m unit -q); then
+              failed=1
+            fi
+          done
+
+          exit ${failed}

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/042.aws-credits-apply/pytest.ini
+++ b/042.aws-credits-apply/pytest.ini
@@ -2,3 +2,6 @@
 testpaths = tests
 python_files = test_*.py
 addopts = -q --cov=scripts --cov-report=term-missing --cov-report=xml --cov-branch
+markers =
+	unit: Unit tests
+	integration: Integration tests

--- a/042.aws-credits-apply/tests/test_apply_credits.py
+++ b/042.aws-credits-apply/tests/test_apply_credits.py
@@ -89,6 +89,7 @@ class FakeContext:
         self.pages = pages
 
 
+@pytest.mark.unit
 def test_load_credit_codes_skips_comments_and_blank_lines(tmp_path):
     csv = tmp_path / "credits.csv"
     csv.write_text("# comment\n\nCODE-1\n  CODE-2  \n", encoding="utf-8")
@@ -98,6 +99,7 @@ def test_load_credit_codes_skips_comments_and_blank_lines(tmp_path):
     assert codes == ["CODE-1", "CODE-2"]
 
 
+@pytest.mark.unit
 def test_load_credit_codes_missing_file_exits(tmp_path):
     missing = tmp_path / "no-file.csv"
 
@@ -107,6 +109,7 @@ def test_load_credit_codes_missing_file_exits(tmp_path):
     assert exc.value.code == 1
 
 
+@pytest.mark.unit
 def test_save_log_creates_json_file(tmp_path, monkeypatch):
     monkeypatch.setattr(apply_credits, "LOGS_DIR", tmp_path / "logs")
     payload = [{"code": "C1", "status": "success"}]
@@ -118,6 +121,7 @@ def test_save_log_creates_json_file(tmp_path, monkeypatch):
     assert data == payload
 
 
+@pytest.mark.unit
 def test_load_runtime_settings_reads_env(monkeypatch):
     monkeypatch.setattr(apply_credits, "load_dotenv", lambda *_args, **_kwargs: None)
     monkeypatch.setenv("LOGIN_URL", "https://example.com/login")
@@ -133,6 +137,7 @@ def test_load_runtime_settings_reads_env(monkeypatch):
     assert settings["login_timeout_ms"] == 12345
 
 
+@pytest.mark.unit
 def test_load_runtime_settings_requires_login_url(monkeypatch):
     monkeypatch.setattr(apply_credits, "load_dotenv", lambda *_args, **_kwargs: None)
     monkeypatch.delenv("LOGIN_URL", raising=False)
@@ -144,6 +149,7 @@ def test_load_runtime_settings_requires_login_url(monkeypatch):
     assert "LOGIN_URL" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_load_runtime_settings_timeout_must_be_integer(monkeypatch):
     monkeypatch.setattr(apply_credits, "load_dotenv", lambda *_args, **_kwargs: None)
     monkeypatch.setenv("LOGIN_URL", "https://example.com/login")
@@ -155,6 +161,7 @@ def test_load_runtime_settings_timeout_must_be_integer(monkeypatch):
     assert "LOGIN_TIMEOUT_MS" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_is_ready_url_exact_and_wildcard():
     assert (
         apply_credits._is_ready_url(
@@ -179,6 +186,7 @@ def test_is_ready_url_exact_and_wildcard():
     )
 
 
+@pytest.mark.integration
 def test_wait_for_ready_page_finds_matching_tab():
     context = FakeContext(
         pages=[
@@ -198,6 +206,7 @@ def test_wait_for_ready_page_finds_matching_tab():
     assert matched.url.startswith("https://us-east-1.console.aws.amazon.com/costmanagement/home")
 
 
+@pytest.mark.integration
 def test_wait_for_ready_page_timeout():
     context = FakeContext(pages=[FakeTab("https://idp.example.com/login")])
 
@@ -211,6 +220,7 @@ def test_wait_for_ready_page_timeout():
         )
 
 
+@pytest.mark.unit
 def test_is_billing_api_response_filters_noise_and_method():
     ok = DummyResponse(200, method="POST", url="https://example.com/redeem")
     noise = DummyResponse(200, method="POST", url="https://example.com/analytics")
@@ -221,6 +231,7 @@ def test_is_billing_api_response_filters_noise_and_method():
     assert apply_credits._is_billing_api_response(get_req) is False
 
 
+@pytest.mark.integration
 def test_apply_credit_success():
     page = FakePage(response=DummyResponse(200), mode="ok")
 
@@ -232,6 +243,7 @@ def test_apply_credit_success():
     assert result["error"] is None
 
 
+@pytest.mark.integration
 def test_apply_credit_failed_non_200():
     page = FakePage(response=DummyResponse(400), mode="ok")
 
@@ -241,6 +253,7 @@ def test_apply_credit_failed_non_200():
     assert result["http_status"] == 400
 
 
+@pytest.mark.integration
 def test_apply_credit_timeout():
     page = FakePage(response=DummyResponse(200), mode="timeout_click")
 
@@ -251,6 +264,7 @@ def test_apply_credit_timeout():
     assert "以内に返りませんでした" in (result["error"] or "")
 
 
+@pytest.mark.integration
 def test_apply_credit_error():
     page = FakePage(response=DummyResponse(200), mode="error_goto")
 
@@ -261,6 +275,7 @@ def test_apply_credit_error():
     assert "goto failed" in (result["error"] or "")
 
 
+@pytest.mark.integration
 def test_apply_credit_failed_when_error_flash_appears(monkeypatch):
     async def fake_detect(_page, timeout_ms=2000):
         return True, "クレジットの適用中に問題が発生しました"
@@ -275,6 +290,7 @@ def test_apply_credit_failed_when_error_flash_appears(monkeypatch):
     assert "問題が発生" in (result["error"] or "")
 
 
+@pytest.mark.integration
 def test_apply_credit_timeout_but_error_flash_means_failed(monkeypatch):
     async def fake_detect(_page, timeout_ms=2000):
         return True, "クレジットの適用中に問題が発生しました"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "description": "Consolidated Node.js dependencies for this repository",
+  "scripts": {
+    "test": "jest",
+    "test:unit": "jest --passWithNoTests --testPathPatterns=unit --testPathPatterns=\\.unit\\. --testPathPatterns=\\.spec\\.",
+    "test:integration": "jest --passWithNoTests --testPathPatterns=integration --testPathPatterns=\\.integration\\."
+  },
   "dependencies": {
     "@aws-sdk/client-sns": "^3.1037.0",
     "@aws-sdk/client-ssm": "^3.1037.0",


### PR DESCRIPTION
## Summary
- split unit test GitHub Actions into separate npm and Python workflows
- update Python unit test workflow to auto-detect directories containing pytest.ini instead of hardcoding one path
- add and align unit/integration marker execution setup for 042 tests and npm scripts

## Validation
- pytest -m unit (042) passed
- pytest -m integration (042) passed
- npm run test:unit executes in CI configuration

## Notes
- includes all current local changes as requested
- draft PR by default