### PR TITLE
chore(dependabot): group github-actions updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ updates:
 - cooldown:
     default-days: 7
   directory: /
+  groups:
+    all-github-actions:
+      patterns:
+      - "*"
   ignore:
   - dependency-name: "github/gh-aw-actions/**"
   - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.


### PR DESCRIPTION
## Summary
- add Dependabot `groups` configuration for `github-actions`
- group all GitHub Actions dependency updates into one PR via `all-github-actions`

## Changes
- update `.github/dependabot.yml`
  - add:
    - `groups.all-github-actions.patterns: ["*"]`

## Why
- reduce PR noise from individual GitHub Actions dependency update PRs
- make weekly update review more efficient

## Validation
- confirmed YAML change is present in the repository
- no runtime code changes